### PR TITLE
Create release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint:fix": "yarn lint -- --fix",
     "test:unit": "NODE_ENV=test jest --maxWorkers=2 --coverage",
     "test": "yarn lint && yarn test:unit",
+    "release": "node scripts/release",
     "alliage:run": "ts-node src/scripts run",
     "alliage:build": "ts-node src/scripts build",
     "alliage:install": "ts-node src/scripts install"

--- a/scripts/release/index.js
+++ b/scripts/release/index.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const pkg = require('../../package.json');
+
+const BASE_DIR = path.resolve(`${__dirname}/../../`);
+const DIST_DIR = path.resolve(`${BASE_DIR}/dist`);
+
+// Removes useless properties from the package.json
+pkg.scripts = undefined;
+pkg.devDependencies = undefined;
+
+// Run the build script
+execSync('npm run build');
+
+// Copy the cleaned version of the 'package.json' file
+fs.writeFileSync(`${DIST_DIR}/package.json`, JSON.stringify(pkg, null, 2));
+
+// Copies the README.md file
+fs.copyFileSync(`${BASE_DIR}/README.md`, `${DIST_DIR}/README.md`);
+
+// Publishes the 'dist' directory
+execSync('npm publish dist');


### PR DESCRIPTION
### Description

Create a script allowing to publish the package on NPM.
This script runs the build command, copies a cleaned version of the package.json and the README.md in the dist directory and publishes the dist directory.
The script is configured to be run through the `npm run release` command.